### PR TITLE
Parsing Literal and BNode terms

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -19,7 +19,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        python-versions: [ "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-versions: ["3.10", "3.11"]
         os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 rdflib
 click
+pathos

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,7 +47,7 @@ class CLITest(unittest.TestCase):
         g = Graph().parse('graph.ttl')
 
         self.assertEqual(response.exit_code, 0)
-        self.assertEqual(len([(s,p,o) for (s,p,o) in g if not (isinstance(s,BNode) or isinstance(o,BNode))]), 248)
+        self.assertEqual(len([(s, p, o) for (s, p, o) in g if not (isinstance(s, BNode) or isinstance(o, BNode))]), 248)
 
     def test_cds_11846_nondefault_output(self):
         """Test parsing a json document and load as graph from specified output file."""
@@ -60,7 +60,7 @@ class CLITest(unittest.TestCase):
         g = Graph().parse('11846.ttl')
 
         self.assertEqual(response.exit_code, 0)
-        self.assertEqual(len([(s,p,o) for (s,p,o) in g if not (isinstance(s,BNode) or isinstance(o,BNode))]), 248)
+        self.assertEqual(len([(s, p, o) for (s, p, o) in g if not (isinstance(s, BNode) or isinstance(o, BNode))]), 248)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ import shutil
 import unittest
 
 from click.testing import CliRunner
-from rdflib import Graph
+from rdflib import Graph, BNode
 
 from tripser.cli import cli
 
@@ -47,7 +47,7 @@ class CLITest(unittest.TestCase):
         g = Graph().parse('graph.ttl')
 
         self.assertEqual(response.exit_code, 0)
-        self.assertEqual(len(g), 674)
+        self.assertEqual(len([(s,p,o) for (s,p,o) in g if not (isinstance(s,BNode) or isinstance(o,BNode))]), 248)
 
     def test_cds_11846_nondefault_output(self):
         """Test parsing a json document and load as graph from specified output file."""
@@ -60,7 +60,7 @@ class CLITest(unittest.TestCase):
         g = Graph().parse('11846.ttl')
 
         self.assertEqual(response.exit_code, 0)
-        self.assertEqual(len(g), 674)
+        self.assertEqual(len([(s,p,o) for (s,p,o) in g if not (isinstance(s,BNode) or isinstance(o,BNode))]), 248)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,7 +47,7 @@ class CLITest(unittest.TestCase):
         g = Graph().parse('graph.ttl')
 
         self.assertEqual(response.exit_code, 0)
-        self.assertEqual(len(g), 42)
+        self.assertEqual(len(g), 674)
 
     def test_cds_11846_nondefault_output(self):
         """Test parsing a json document and load as graph from specified output file."""
@@ -60,7 +60,7 @@ class CLITest(unittest.TestCase):
         g = Graph().parse('11846.ttl')
 
         self.assertEqual(response.exit_code, 0)
-        self.assertEqual(len(g), 42)
+        self.assertEqual(len(g), 674)
 
 
 if __name__ == "__main__":

--- a/tests/test_tripser.py
+++ b/tests/test_tripser.py
@@ -65,7 +65,7 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         parser.parse()
 
         self.assertIsInstance(parser.graph, Graph)
-        self.assertGreater(len(parser.graph), 800)
+        self.assertEqual(len(parser.graph), 923)
 
     def test_parse_page_cds(self):
         """Test parsing a CDS with all subclasses."""
@@ -77,7 +77,7 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         cds_graph = parser.parse_page(cds_page)
 
         self.assertIsInstance(cds_graph, Graph)
-        self.assertGreater(len(cds_graph), 800)
+        self.assertEqual(len(cds_graph), 1377)
 
     @unittest.skip("Takes too long.")
     def test_parse_page(self):
@@ -90,7 +90,7 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         cds_graph = parser.parse_page(cds_page)
 
         self.assertIsInstance(cds_graph, Graph)
-        self.assertGreater(len(cds_graph), 5300)
+        self.assertEqual(len(cds_graph), 5300)
 
         # Get number of unique CDS subjects, should be 10.
         self.assertEqual(
@@ -117,7 +117,7 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
                                    ref=URIRef(parser.entry_point))
 
         self.assertIsInstance(g, Graph)
-        self.assertGreater(len(g), 600)
+        self.assertEqual(len(g), 674)
 
     @unittest.skip("Takes too long.")
     def test_recursively_add_trna(self):
@@ -130,7 +130,7 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         logging.debug("# Terms")
         for term in g:
             logging.debug("\t %s", str(term))
-        self.assertGreater(len(g), 4500)
+        self.assertEqual(len(g), 4500)
 
         # Get number of unique TRNAs subjects, should be 1.
         self.assertEqual(
@@ -158,7 +158,7 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         logging.debug("# Terms")
         for term in g:
             logging.debug("\t %s", str(term))
-        self.assertGreater(len(g), 100)
+            self.assertEqual(len(g), 136)
 
         # Get number of unique TMRNAs subjects, should be 1.
         self.assertEqual(
@@ -176,6 +176,38 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
             ),
             1,
         )
+
+    def test_construct_and_parse(self):
+        """ Test instantiating and using the class. """
+
+        # Construct the parser.
+        parser = RecursiveJSONLDParser(URIRef('http://pflu.evolbio.mpg.de/web-services/content/v0.1/TMRNA'))
+
+        # Parse.
+        parser.parse()
+
+        # Get the graph.
+        g = parser.graph
+
+        # Clean it up.
+        cleanup(g)
+
+        self.assertGreater(len(g), 0)
+
+    def test_graph_len_consistent(self):
+        """ Test that the length of the queried graph is always the same in consequtive parsings"""
+
+        parser_1 = RecursiveJSONLDParser(URIRef('http://pflu.evolbio.mpg.de/web-services/content/v0.1/TMRNA'))
+        parser_1.parse()
+        g_1 = parser_1.graph
+        cleanup(g_1)
+
+        parser_2 = RecursiveJSONLDParser(URIRef('http://pflu.evolbio.mpg.de/web-services/content/v0.1/TMRNA'))
+        parser_2.parse()
+        g_2 = parser_2.graph
+        cleanup(g_2)
+
+        self.assertEqual(len(g_1), len(g_2))
 
     def test_get_graph_corrupt_json(self):
         """Test get_graph() for a corrupt json file."""

--- a/tests/test_tripser.py
+++ b/tests/test_tripser.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import unittest
 
-from rdflib import Graph, URIRef
+from rdflib import Graph, URIRef, Literal, BNode
 
 from tripser.tripser import RecursiveJSONLDParser
 from tripser.tripser import cleanup, get_graph, remove_terms
@@ -65,7 +65,11 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         parser.parse()
 
         self.assertIsInstance(parser.graph, Graph)
-        self.assertEqual(len(parser.graph), 923)
+
+        # Can only check non-BNode terms
+        self.assertEqual(
+            len([(s,p,o) for (s,p,o) in parser.graph if not (isinstance(s,BNode) or isinstance(o,BNode))]),
+            247)
 
     def test_parse_page_cds(self):
         """Test parsing a CDS with all subclasses."""
@@ -77,7 +81,9 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         cds_graph = parser.parse_page(cds_page)
 
         self.assertIsInstance(cds_graph, Graph)
-        self.assertEqual(len(cds_graph), 1377)
+        self.assertEqual(
+            len([(s,p,o) for (s,p,o) in cds_graph if not (isinstance(s,BNode) or isinstance(o,BNode))]),
+            253)
 
     @unittest.skip("Takes too long.")
     def test_parse_page(self):
@@ -90,7 +96,6 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         cds_graph = parser.parse_page(cds_page)
 
         self.assertIsInstance(cds_graph, Graph)
-        self.assertEqual(len(cds_graph), 5300)
 
         # Get number of unique CDS subjects, should be 10.
         self.assertEqual(
@@ -117,7 +122,10 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
                                    ref=URIRef(parser.entry_point))
 
         self.assertIsInstance(g, Graph)
-        self.assertEqual(len(g), 674)
+
+        self.assertEqual(
+            len([(s,p,o) for (s,p,o) in g if not (isinstance(s,BNode) or isinstance(o,BNode))]),
+            248)
 
     @unittest.skip("Takes too long.")
     def test_recursively_add_trna(self):
@@ -130,7 +138,6 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         logging.debug("# Terms")
         for term in g:
             logging.debug("\t %s", str(term))
-        self.assertEqual(len(g), 4500)
 
         # Get number of unique TRNAs subjects, should be 1.
         self.assertEqual(
@@ -158,7 +165,10 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         logging.debug("# Terms")
         for term in g:
             logging.debug("\t %s", str(term))
-            self.assertEqual(len(g), 136)
+
+        self.assertEqual(
+            len([(s,p,o) for (s,p,o) in g if not (isinstance(s,BNode) or isinstance(o,BNode))]),
+            92)
 
         # Get number of unique TMRNAs subjects, should be 1.
         self.assertEqual(

--- a/tests/test_tripser.py
+++ b/tests/test_tripser.py
@@ -11,6 +11,8 @@ from rdflib import Graph, URIRef
 
 from tripser.tripser import cleanup, get_graph, parse_page, recursively_add, remove_terms
 
+logging.getLogger(__name__).setLevel(logging.INFO)
+
 
 class TestTripser(unittest.TestCase):
     def setUp(self):
@@ -98,7 +100,33 @@ class TestTripser(unittest.TestCase):
         self.assertIsInstance(g, Graph)
         self.assertEqual(len(g), 42)
 
-    def test_recursively_add_class(self):
+    def test_recursively_add_trna(self):
+        """Test recursively adding terms to a graph (with members)."""
+        g = recursively_add(Graph(), ref=URIRef('http://pflu.evolbio.mpg.de/web-services/content/v0.1/TRNA'))
+
+        logging.debug("# Terms")
+        for term in g:
+            logging.debug("\t %s", str(term))
+        self.assertEqual(len(g), 1731)
+
+        # Get number of unique TMRNAs subjects, should be 1.
+        self.assertEqual(
+            len(
+                [
+                    tr
+                    for tr in g.triples(
+                        (
+                            None,
+                            URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+                            URIRef('http://www.sequenceontology.org/browser/current_svn/term/SO:0000253'),
+                        )
+                    )
+                ]
+            ),
+            66,
+        )
+
+    def test_recursively_add_tmrna(self):
         """Test recursively adding terms to a graph (with members)."""
         g = recursively_add(Graph(), ref=URIRef('http://pflu.evolbio.mpg.de/web-services/content/v0.1/TMRNA'))
 

--- a/tests/test_tripser.py
+++ b/tests/test_tripser.py
@@ -11,8 +11,7 @@ from rdflib import Graph, URIRef
 
 from tripser.tripser import cleanup, get_graph, parse_page, recursively_add, remove_terms
 
-logging.getLogger(__name__).setLevel(logging.INFO)
-
+logging.basicConfig(level=logging.DEBUG)
 
 class TestTripser(unittest.TestCase):
     def setUp(self):
@@ -56,10 +55,20 @@ class TestTripser(unittest.TestCase):
         # There should be 40 terms in this graph.
         self.assertEqual(len(graph), 40)
 
+    def test_recursively_add_cds(self):
+        """Test adding a CDS with all subclasses."""
+
+        cds_page = "http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/11845"
+
+        cds_graph = recursively_add(Graph(), cds_page)
+
+        self.assertIsInstance(cds_graph, Graph)
+        self.assertEqual(len(cds_graph), 570)
+
     def test_parse_page_cds(self):
         """Test parsing a CDS with all subclasses."""
 
-        cds_page = "http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/11845"
+        cds_page = "http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS?page=1&limit=1"
 
         cds_graph = parse_page(cds_page)
 

--- a/tests/test_tripser.py
+++ b/tests/test_tripser.py
@@ -9,11 +9,12 @@ import unittest
 
 from rdflib import Graph, URIRef
 
-from tripser.tripser import cleanup, get_graph, parse_page, recursively_add, remove_terms
+from tripser.tripser import RecursiveJSONLDParser
+from tripser.tripser import cleanup, get_graph, remove_terms
 
 logging.basicConfig(level=logging.DEBUG)
 
-class TestTripser(unittest.TestCase):
+class TestRecursiveJSONLDParser(unittest.TestCase):
     def setUp(self):
         """Set up the test case."""
 
@@ -60,20 +61,23 @@ class TestTripser(unittest.TestCase):
 
         cds_page = "http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/11845"
 
-        cds_graph = recursively_add(Graph(), cds_page)
+        parser = RecursiveJSONLDParser(cds_page)
+        parser.parse()
 
-        self.assertIsInstance(cds_graph, Graph)
-        self.assertEqual(len(cds_graph), 570)
+        self.assertIsInstance(parser.graph, Graph)
+        self.assertEqual(len(parser.graph), 570)
 
     def test_parse_page_cds(self):
         """Test parsing a CDS with all subclasses."""
 
         cds_page = "http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS?page=1&limit=1"
 
-        cds_graph = parse_page(cds_page)
+        parser = RecursiveJSONLDParser(cds_page)
 
-        self.assertIsInstance(cds_graph, Graph)
-        self.assertEqual(len(cds_graph), 570)
+        parser.parse_page(cds_page)
+
+        self.assertIsInstance(parser.graph, Graph)
+        self.assertEqual(len(parser.graph), 570)
 
     def test_parse_page(self):
         """Test parsing a URL with members."""

--- a/tests/test_tripser.py
+++ b/tests/test_tripser.py
@@ -7,12 +7,13 @@ import os
 import shutil
 import unittest
 
-from rdflib import Graph, URIRef, Literal, BNode
+from rdflib import Graph, URIRef, BNode
 
 from tripser.tripser import RecursiveJSONLDParser
 from tripser.tripser import cleanup, get_graph, remove_terms
 
 logging.basicConfig(level=logging.INFO)
+
 
 class TestRecursiveJSONLDParser(unittest.TestCase):
     def setUp(self):
@@ -43,7 +44,6 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         # There should be 125 terms in this graph.
         self.assertEqual(len(graph), 125)
 
-
     def test_get_graph(self):
         """Test parsing a URL into a graph."""
 
@@ -68,8 +68,8 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
 
         # Can only check non-BNode terms
         self.assertEqual(
-            len([(s,p,o) for (s,p,o) in parser.graph if not (isinstance(s,BNode) or isinstance(o,BNode))]),
-            247)
+            len([(s, p, o) for (s, p, o) in parser.graph if not (isinstance(s, BNode) or isinstance(o, BNode))]), 247
+        )
 
     def test_parse_page_cds(self):
         """Test parsing a CDS with all subclasses."""
@@ -82,8 +82,8 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
 
         self.assertIsInstance(cds_graph, Graph)
         self.assertEqual(
-            len([(s,p,o) for (s,p,o) in cds_graph if not (isinstance(s,BNode) or isinstance(o,BNode))]),
-            253)
+            len([(s, p, o) for (s, p, o) in cds_graph if not (isinstance(s, BNode) or isinstance(o, BNode))]), 253
+        )
 
     @unittest.skip("Takes too long.")
     def test_parse_page(self):
@@ -118,22 +118,17 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         """Test recursively adding terms to a graph (no members)."""
 
         parser = RecursiveJSONLDParser('http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/11846')
-        g = parser.recursively_add(Graph(),
-                                   ref=URIRef(parser.entry_point))
+        g = parser.recursively_add(Graph(), ref=URIRef(parser.entry_point))
 
         self.assertIsInstance(g, Graph)
 
-        self.assertEqual(
-            len([(s,p,o) for (s,p,o) in g if not (isinstance(s,BNode) or isinstance(o,BNode))]),
-            248)
+        self.assertEqual(len([(s, p, o) for (s, p, o) in g if not (isinstance(s, BNode) or isinstance(o, BNode))]), 248)
 
     @unittest.skip("Takes too long.")
     def test_recursively_add_trna(self):
         """Test recursively adding terms to a graph (with members)."""
         parser = RecursiveJSONLDParser('http://pflu.evolbio.mpg.de/web-services/content/v0.1/TRNA/')
-        g = parser.recursively_add(Graph(),
-                                   ref=parser.entry_point
-                                   )
+        g = parser.recursively_add(Graph(), ref=parser.entry_point)
 
         logging.debug("# Terms")
         for term in g:
@@ -166,9 +161,7 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         for term in g:
             logging.debug("\t %s", str(term))
 
-        self.assertEqual(
-            len([(s,p,o) for (s,p,o) in g if not (isinstance(s,BNode) or isinstance(o,BNode))]),
-            92)
+        self.assertEqual(len([(s, p, o) for (s, p, o) in g if not (isinstance(s, BNode) or isinstance(o, BNode))]), 92)
 
         # Get number of unique TMRNAs subjects, should be 1.
         self.assertEqual(
@@ -188,7 +181,7 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         )
 
     def test_construct_and_parse(self):
-        """ Test instantiating and using the class. """
+        """Test instantiating and using the class."""
 
         # Construct the parser.
         parser = RecursiveJSONLDParser(URIRef('http://pflu.evolbio.mpg.de/web-services/content/v0.1/TMRNA'))
@@ -205,7 +198,7 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         self.assertGreater(len(g), 0)
 
     def test_graph_len_consistent(self):
-        """ Test that the length of the queried graph is always the same in consequtive parsings"""
+        """Test that the length of the queried graph is always the same in consequtive parsings"""
 
         parser_1 = RecursiveJSONLDParser(URIRef('http://pflu.evolbio.mpg.de/web-services/content/v0.1/TMRNA'))
         parser_1.parse()

--- a/tests/test_tripser.py
+++ b/tests/test_tripser.py
@@ -29,6 +29,19 @@ class TestTripser(unittest.TestCase):
             elif os.path.isdir(item):
                 shutil.rmtree(item)
 
+    def test_get_graph_dbxref(self):
+        """Test parsing a URL for dbxref's into a graph."""
+
+        page = "http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/11845/database%20cross%20reference"
+
+        graph = get_graph(page)
+
+        self.assertIsInstance(graph, Graph)
+
+        # There should be 40 terms in this graph.
+        self.assertEqual(len(graph), 125)
+
+
     def test_get_graph(self):
         """Test parsing a URL into a graph."""
 
@@ -40,6 +53,16 @@ class TestTripser(unittest.TestCase):
 
         # There should be 40 terms in this graph.
         self.assertEqual(len(graph), 40)
+
+    def test_parse_page_cds(self):
+        """Test parsing a CDS with all subclasses."""
+
+        cds_page = "http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/11845"
+
+        cds_graph = parse_page(cds_page)
+
+        self.assertIsInstance(cds_graph, Graph)
+        self.assertEqual(len(cds_graph), 570)
 
     def test_parse_page(self):
         """Test parsing a URL with members."""
@@ -77,11 +100,14 @@ class TestTripser(unittest.TestCase):
 
     def test_recursively_add_class(self):
         """Test recursively adding terms to a graph (with members)."""
-        g = recursively_add(Graph(), ref=URIRef('http://pflu.evolbio.mpg.de/web-services/content/v0.1/TRNA'))
+        g = recursively_add(Graph(), ref=URIRef('http://pflu.evolbio.mpg.de/web-services/content/v0.1/TMRNA'))
 
-        self.assertEqual(len(g), 1732)
+        logging.debug("# Terms")
+        for term in g:
+            logging.debug("\t %s", str(term))
+        self.assertEqual(len(g), 42)
 
-        # Get number of unique TRNAs subjects, should be 66.
+        # Get number of unique TMRNAs subjects, should be 1.
         self.assertEqual(
             len(
                 [
@@ -90,12 +116,12 @@ class TestTripser(unittest.TestCase):
                         (
                             None,
                             URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
-                            URIRef('http://www.sequenceontology.org/browser/current_svn/term/SO:0000253'),
+                            URIRef('http://www.sequenceontology.org/browser/current_svn/term/SO:0000584'),
                         )
                     )
                 ]
             ),
-            66,
+            1,
         )
 
     def test_get_graph_corrupt_json(self):

--- a/tripser/cli.py
+++ b/tripser/cli.py
@@ -2,10 +2,7 @@
 """Console script for tripser."""
 
 import logging
-
 import click
-from rdflib import Graph
-
 from tripser import tripser
 
 logging.basicConfig(level=logging.INFO)

--- a/tripser/cli.py
+++ b/tripser/cli.py
@@ -8,6 +8,7 @@ from rdflib import Graph
 
 from tripser import tripser
 
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("tripser.cli")
 logger.setLevel(logging.INFO)
 
@@ -21,15 +22,20 @@ def cli(url, out):
     click.echo("=" * len("pytripalserializer"))
     click.echo("Serialize Tripal's JSON-LD API into RDF.")
 
+    parser = tripser.RecursiveJSONLDParser(url)
+
     try:
-        g = tripser.recursively_add(Graph(), url)
+        parser.parse()
+        g = parser.graph
         tripser.cleanup(g)
         g.serialize(out)
         logger.info(
             "Successfully parsed %s. After cleanup, %d triples remain and will be written to %s", url, len(g), out
         )
-    except Exception:
+    except Exception as e:
         logger.error("Could not parse '%s', please check the URL.", url)
+        if logger.level == logging.DEBUG:
+            raise e
 
 
 if __name__ == "__main__":

--- a/tripser/tripser.py
+++ b/tripser/tripser.py
@@ -12,7 +12,7 @@ import urllib
 import requests
 from rdflib import Graph, URIRef
 
-logging.basicConfig(level=logging.DEBUG)
+logging.getLogger(__name__).setLevel(logging.WARN)
 
 
 def parse_page(page):

--- a/tripser/tripser.py
+++ b/tripser/tripser.py
@@ -114,11 +114,6 @@ class RecursiveJSONLDParser():
         :param ref: The URL of the document to (recursively) parse into the graph
         :type  ref: URIRef | str
         """
-        if str(ref) in self.__parsed_pages:
-            logger.debug("Already parsed or parsing: %s", str(page))
-            return Graph()
-
-        self.__parsed_pages.append(str(ref))
         logger.debug("recursively_add(g=%s, ref=%s)", str(g), str(ref))
         # First parse the document into a local g.
         # gloc = get_graph(ref)

--- a/tripser/tripser.py
+++ b/tripser/tripser.py
@@ -4,9 +4,6 @@
 import json
 import logging
 import math
-from pathos.multiprocessing import ProcessPool
-import pathos.multiprocessing as multiprocess
-import tempfile
 
 import urllib
 import requests
@@ -85,8 +82,6 @@ class RecursiveJSONLDParser:
         logger.debug("parse_page(page=%s)", str(page))
 
         grph = get_graph(page)
-
-        subjects = [s for s in grph.subjects()]
 
         logger.debug("# Terms")
         for term in grph:

--- a/tripser/tripser.py
+++ b/tripser/tripser.py
@@ -12,187 +12,210 @@ import urllib
 import requests
 from rdflib import Graph, URIRef
 
-# logging.getLogger(__name__).setLevel(logging.WARN)
+logger = logging.getLogger(__name__)
+
+class RecursiveJSONLDParser():
+    """:class: This class implements recursive parsing of JSON-LD documents."""
+
+    def __init__(self, entry_point=None):
+        """ Initialize the recursine JSON-LD parser.
+
+        :param root: The entry point for parsing.
+        :type  root: str | rdflib.URIRef | rdflib.Literal
+
+        """
+
+        self.__parsed_pages = []
+
+        self.graph = Graph()
+
+        self.entry_point = URIRef(entry_point)
+
+    @property
+    def parsed_pages(self):
+        return self.__parsed_pages
+
+    @parsed_pages.setter
+    def parsed_pages(self, value):
+        raise RuntimeError("parsed_pages is a read-only property.")
 
 
-def parse_page(page):
-    """
-    This function will attempt to get the json-ld blob from the passed page (URL) and pass it on to Graph.parse().
-    It then calls the `recursively_add` function on the local scope's graph and for each member's URI.
+    @property
+    def graph(self):
+        return self.__graph
 
-    The constructed Graph instance is returned.
+    @graph.setter
+    def graph(self, value):
+        if isinstance(value, Graph):
+            self.__graph = value
+        else:
+            raise TypeError("{} is not a rdflib.Graph instance.".format(value))
 
-    :param page: URL of the json-ld document
-    :type  page: str
+    @property
+    def entry_point(self):
+        return self.__entry_point
 
-    :return: A Graph instance constructed from the downloaded json document.
-    :rtype: Graph
-    """
+    @entry_point.setter
+    def entry_point(self, value):
+        if isinstance(value, str):
+            value = URIRef(value)
 
-    logging.debug("parse_page(page=%s)", str(page))
-    grph = get_graph(page)
+        if not isinstance(value, URIRef):
+            raise TypeError("{} is neither a rdflib.URIRef instance nor str.".format(value))
+        else:
+            self.__entry_point = value
 
-    subjects = [s for s in grph.subjects()]
+    def parse(self):
+        self.graph += self.parse_page(self.entry_point)
 
-    logging.debug("# Terms")
-    for term in grph:
-        logging.debug("\t %s", str(term))
-        subj, pred, obj = term
-        if pred == URIRef("http://www.w3.org/ns/hydra/core#PartialCollectionView"):
-            continue
-        if obj.startswith("http://pflu.evolbio.mpg.de/web-services/content/"):
-            logging.debug("Descending into 'recursively_add()'")
-            grph = recursively_add(grph, obj)
-    return grph
+    def parse_page(self, page):
+        """
+        This function will attempt to get the json-ld blob from the passed page (URL) and pass it on to Graph.parse().
+        It then calls the `recursively_add` function on the local scope's graph and for each member's URI.
 
-def get_graph(page):
-    """Workhorse function to download the json document and parse into the graph to be returned.
+        The constructed Graph instance is returned.
 
-    :param page: The URL of the json-ld document to download and parse.
-    :type  page: str | URIRef
+        :param page: URL of the json-ld document
+        :type  page: str
 
-    :return: A graph containing all terms found in the downloaded json-ld document.
-    :rtype: rdflib.Graph
+        :return: A Graph instance constructed from the downloaded json document.
+        :rtype: Graph
+        """
 
-    """
+        logger.debug("parse_page(page=%s)", str(page))
 
-    logging.debug("get_graph(graph=%s)", str(page))
-    logging.debug("Setting up empty graph.")
-    grph = Graph()
+        grph = get_graph(page)
 
-    logging.debug("Attempting to parse %s", page)
-    try:
-        response = requests.get(page, timeout=600)
-        jsn = json.dumps(response.json())
-        jsn = jsn.replace('https://pflu', 'http://pflu')
-        jsn = urllib.parse.unquote(jsn)
+        subjects = [s for s in grph.subjects()]
 
-        grph.parse(data=jsn, format='json-ld')
+        logger.debug("# Terms")
+        for term in grph:
+            logger.debug("\t %s", str(term))
+            subj, pred, obj = term
+            if str(obj) in self.__parsed_pages:
+                logger.debug("Already parsed or parsing: %s", str(page))
+                continue
+            if pred == URIRef("http://www.w3.org/ns/hydra/core#PartialCollectionView"):
+                continue
+            if obj.startswith("http://pflu.evolbio.mpg.de/web-services/content/"):
+                self.__parsed_pages.append(str(page))
+                logger.debug("Descending into 'recursively_add()'")
+                grph = self.recursively_add(grph, obj)
+        return grph
 
+    def recursively_add_serial(self, g, ref):
+        """
+        Parse the document in `ref` into the graph `g`. Then call this function on all 'member' objects of the
+        subgraph with the same graph `g`. Serial implementation
 
-    except json.decoder.JSONDecodeError:
-        logging.warning("Not a valid JSON document: %s", page)
+        :param g: The graph into which all terms are to be inserted.
+        :type  g: rdflib.Graph
 
-    except requests.exceptions.JSONDecodeError:
-        logging.warning("Not a valid JSON document: %s", page)
+        :param ref: The URL of the document to (recursively) parse into the graph
+        :type  ref: URIRef | str
+        """
+        if str(ref) in self.__parsed_pages:
+            logger.debug("Already parsed or parsing: %s", str(page))
+            return Graph()
 
-    except BaseException:
-        logging.error("Exception thrown while parsing %s.", page)
-        raise
+        self.__parsed_pages.append(str(ref))
+        logger.debug("recursively_add(g=%s, ref=%s)", str(g), str(ref))
+        # First parse the document into a local g.
+        # gloc = get_graph(ref)
+        gloc = self.parse_page(ref)
 
-    logging.debug("Parsed %d terms.", len(grph))
-    return grph
+        # Get total item count.
+        number_of_members = [ti for ti in gloc.objects(predicate=URIRef("http://www.w3.org/ns/hydra/core#totalItems"))]
 
-def recursively_add_serial(g, ref):
-    """
-    Parse the document in `ref` into the graph `g`. Then call this function on all 'member' objects of the
-    subgraph with the same graph `g`. Serial implementation
+        # If there are any member, parse them recursively.
+        if number_of_members != []:
+            # Convert to python type.
+            nom = number_of_members[0].toPython()
+            if nom == 0:
+                return g + gloc
 
-    :param g: The graph into which all terms are to be inserted.
-    :type  g: rdflib.Graph
+            logger.info("Found %d members in %s.", nom, ref.toPython())
 
-    :param ref: The URL of the document to (recursively) parse into the graph
-    :type  ref: URIRef | str
-    """
+            # We'll apply pagination with 25 items per page.
+            limit = 25
+            pages = range(1, math.ceil(nom / limit) + 1)
 
-    logging.debug("recursively_add(g=%s, ref=%s)", str(g), str(ref))
-    # First parse the document into a local g.
-    # gloc = get_graph(ref)
-    gloc = parse_page(ref)
+            # Get each page's URL.
+            pages = [ref + "?limit={}&page={}".format(limit, page) for page in pages]
+            logger.debug("# PAGES")
+            for page in pages:
+                logger.debug("\t %s", page)
 
-    # Get total item count.
-    number_of_members = [ti for ti in gloc.objects(predicate=URIRef("http://www.w3.org/ns/hydra/core#totalItems"))]
+            igraphs = (self.parse_page(page) for page in pages)
 
-    # If there are any member, parse them recursively.
-    if number_of_members != []:
-        # Convert to python type.
-        nom = number_of_members[0].toPython()
-        if nom == 0:
-            return g + gloc
+            logger.info("Parsing and merging subgraphs in %s.", ref)
+            for grph in igraphs:
+                gloc = gloc + grph
 
-        logging.info("Found %d members in %s.", nom, ref.toPython())
-
-        # We'll apply pagination with 25 items per page.
-        limit = 25
-        pages = range(1, math.ceil(nom / limit) + 1)
-
-        # Get each page's URL.
-        pages = [ref + "?limit={}&page={}".format(limit, page) for page in pages]
-        logging.debug("# PAGES")
-        for page in pages:
-            logging.debug("\t %s", page)
-
-        igraphs = (parse_page(page) for page in pages)
-
-        logging.info("Parsing and merging subgraphs in %s.", ref)
-        for grph in igraphs:
-            gloc = gloc + grph
-
-    return g + gloc
+        return g + gloc
 
 
-def recursively_add(g, ref):
-    """
-    Parse the document in `ref` into the graph `g`. Then call this function on all 'member' objects of the
-    subgraph with the same graph `g`.
+    def recursively_add(self, g, ref):
+        """
+        Parse the document in `ref` into the graph `g`. Then call this function on all 'member' objects of the
+        subgraph with the same graph `g`.
 
-    :param g: The graph into which all terms are to be inserted.
-    :type  g: rdflib.Graph
+        :param g: The graph into which all terms are to be inserted.
+        :type  g: rdflib.Graph
 
-    :param ref: The URL of the document to (recursively) parse into the graph
-    :type  ref: URIRef | str
-    """
+        :param ref: The URL of the document to (recursively) parse into the graph
+        :type  ref: URIRef | str
+        """
 
-    return recursively_add_serial(g, ref)
+        return self.recursively_add_serial(g, ref)
 
-    # First parse the document into a local g.
-    gloc = get_graph(ref)
-    # gloc = Graph().parse(ref)
+#         # First parse the document into a local g.
+#         gloc = get_graph(ref)
+#         # gloc = Graph().parse(ref)
 
-    # Get total item count.
-    number_of_members = [ti for ti in gloc.objects(predicate=URIRef("http://www.w3.org/ns/hydra/core#totalItems"))]
+#         # Get total item count.
+#         number_of_members = [ti for ti in gloc.objects(predicate=URIRef("http://www.w3.org/ns/hydra/core#totalItems"))]
 
-    # If there are any member, parse them recursively.
-    if number_of_members != []:
-        # Convert to python type.
-        nom = number_of_members[0].toPython()
-        if nom == 0:
-            return g + gloc
+#         # If there are any member, parse them recursively.
+#         if number_of_members != []:
+#             # Convert to python type.
+#             nom = number_of_members[0].toPython()
+#             if nom == 0:
+#                 return g + gloc
 
-        logging.info("Found %d members in %s.", nom, ref.toPython())
+#             logger.info("Found %d members in %s.", nom, ref.toPython())
 
-        # We'll apply pagination with 25 items per page.
-        limit = 25
-        pages = range(1, math.ceil(nom / limit) + 1)
+#             # We'll apply pagination with 25 items per page.
+#             limit = 25
+#             pages = range(1, math.ceil(nom / limit) + 1)
 
-        # Get each page's URL.
-        pages = [ref + "?limit={}&page={}".format(limit, page) for page in pages]
+#             # Get each page's URL.
+#             pages = [ref + "?limit={}&page={}".format(limit, page) for page in pages]
 
-        # Get pool of workers and  distribute tasks.
-        number_of_tasks = len(pages)
-        number_of_processes = min(multiprocess.cpu_count(), number_of_tasks)
-        chunk_size = number_of_tasks // number_of_processes
+#             # Get pool of workers and  distribute tasks.
+#             number_of_tasks = len(pages)
+#             number_of_processes = min(multiprocess.cpu_count(), number_of_tasks)
+#             chunk_size = number_of_tasks // number_of_processes
 
-        logging.info("### MultiProcessing setup")
-        logging.info("### Number of tasks:\t\t%d", number_of_tasks)
-        logging.info("### Number of processes:\t%d", number_of_processes)
-        logging.info("### Chunk size:\t\t%d", chunk_size)
+#             logger.info("### MultiProcessing setup")
+#             logger.info("### Number of tasks:\t\t%d", number_of_tasks)
+#             logger.info("### Number of processes:\t%d", number_of_processes)
+#             logger.info("### Chunk size:\t\t%d", chunk_size)
 
-        with ProcessPool(nodes=number_of_processes) as pool:
-            logging.debug("Setup pool %s.", str(pool))
-            list_of_graphs = pool.amap(parse_page, pages, chunksize=chunk_size).get()
+#             with ProcessPool(nodes=number_of_processes) as pool:
+#                 logger.debug("Setup pool %s.", str(pool))
+#                 list_of_graphs = pool.amap(parse_page, pages, chunksize=chunk_size).get()
 
-            pool.close()
-            pool.join()
+#                 pool.close()
+#                 pool.join()
 
-        logging.info("Done parsing subgraphs in %s.", ref)
+#             logger.info("Done parsing subgraphs in %s.", ref)
 
-        logging.info("Merging subgraphs in %s.", ref)
-        for grph in list_of_graphs:
-            gloc = gloc + grph
+#             logger.info("Merging subgraphs in %s.", ref)
+#             for grph in list_of_graphs:
+#                 gloc = gloc + grph
 
-    return g + gloc
-
+#         return g + gloc
 
 def cleanup(grph):
     """
@@ -211,7 +234,6 @@ def cleanup(grph):
 
     remove_terms(grph, (None, URIRef('http://www.w3.org/ns/hydra/core#PartialCollectionView'), None))
 
-
 def remove_terms(grph, terms):
     """
     Remove terms matching the passed pattern `terms` from `grph`.
@@ -229,4 +251,44 @@ def remove_terms(grph, terms):
         grph.remove(t)
         count += 1
 
-    logging.debug("Removed %d terms matching triple pattern (%s, %s, %s).", count, *terms)
+    logger.debug("Removed %d terms matching triple pattern (%s, %s, %s).", count, *terms)
+
+
+
+def get_graph(page):
+    """Workhorse function to download the json document and parse into the graph to be returned.
+
+    :param page: The URL of the json-ld document to download and parse.
+    :type  page: str | URIRef
+
+    :return: A graph containing all terms found in the downloaded json-ld document.
+    :rtype: rdflib.Graph
+
+    """
+
+    logger.debug("get_graph(graph=%s)", str(page))
+    logger.debug("Setting up empty graph.")
+    grph = Graph()
+
+    logger.debug("Attempting to parse %s", page)
+    try:
+        response = requests.get(page, timeout=600)
+        jsn = json.dumps(response.json())
+        jsn = jsn.replace('https://pflu', 'http://pflu')
+        jsn = urllib.parse.unquote(jsn)
+
+        grph.parse(data=jsn, format='json-ld')
+
+
+    except json.decoder.JSONDecodeError:
+        logger.warning("Not a valid JSON document: %s", page)
+
+    except requests.exceptions.JSONDecodeError:
+        logger.warning("Not a valid JSON document: %s", page)
+
+    except BaseException:
+        logger.error("Exception thrown while parsing %s.", page)
+        raise
+
+    logger.debug("Parsed %d terms.", len(grph))
+    return grph

--- a/tripser/tripser.py
+++ b/tripser/tripser.py
@@ -93,14 +93,15 @@ class RecursiveJSONLDParser():
             logger.debug("\t %s", str(term))
             subj, pred, obj = term
             if str(obj) in self.__parsed_pages:
-                logger.debug("Already parsed or parsing: %s", str(page))
+                logger.debug("Already parsed or parsing: %s", str(obj))
                 continue
             if pred == URIRef("http://www.w3.org/ns/hydra/core#PartialCollectionView"):
                 continue
             if obj.startswith("http://pflu.evolbio.mpg.de/web-services/content/"):
-                self.__parsed_pages.append(str(page))
+                self.__parsed_pages.append(str(obj))
                 logger.debug("Descending into 'recursively_add()'")
                 grph = self.recursively_add(grph, obj)
+
         return grph
 
     def recursively_add_serial(self, g, ref):

--- a/tripser/tripser.py
+++ b/tripser/tripser.py
@@ -14,11 +14,12 @@ from rdflib import Graph, URIRef
 
 logger = logging.getLogger(__name__)
 
-class RecursiveJSONLDParser():
+
+class RecursiveJSONLDParser:
     """:class: This class implements recursive parsing of JSON-LD documents."""
 
     def __init__(self, entry_point=None):
-        """ Initialize the recursine JSON-LD parser.
+        """Initialize the recursine JSON-LD parser.
 
         :param root: The entry point for parsing.
         :type  root: str | rdflib.URIRef | rdflib.Literal
@@ -38,7 +39,6 @@ class RecursiveJSONLDParser():
     @parsed_pages.setter
     def parsed_pages(self, value):
         raise RuntimeError("parsed_pages is a read-only property.")
-
 
     @property
     def graph(self):
@@ -150,7 +150,6 @@ class RecursiveJSONLDParser():
 
         return g + gloc
 
-
     def recursively_add(self, g, ref):
         """
         Parse the document in `ref` into the graph `g`. Then call this function on all 'member' objects of the
@@ -165,12 +164,14 @@ class RecursiveJSONLDParser():
 
         return self.recursively_add_serial(g, ref)
 
+
 #         # First parse the document into a local g.
 #         gloc = get_graph(ref)
 #         # gloc = Graph().parse(ref)
 
 #         # Get total item count.
-#         number_of_members = [ti for ti in gloc.objects(predicate=URIRef("http://www.w3.org/ns/hydra/core#totalItems"))]
+#         number_of_members = [ti for ti in gloc.objects(
+#                                 predicate=URIRef("http://www.w3.org/ns/hydra/core#totalItems"))]
 
 #         # If there are any member, parse them recursively.
 #         if number_of_members != []:
@@ -213,6 +214,7 @@ class RecursiveJSONLDParser():
 
 #         return g + gloc
 
+
 def cleanup(grph):
     """
     Remove:
@@ -229,6 +231,7 @@ def cleanup(grph):
     )
 
     remove_terms(grph, (None, URIRef('http://www.w3.org/ns/hydra/core#PartialCollectionView'), None))
+
 
 def remove_terms(grph, terms):
     """
@@ -248,7 +251,6 @@ def remove_terms(grph, terms):
         count += 1
 
     logger.debug("Removed %d terms matching triple pattern (%s, %s, %s).", count, *terms)
-
 
 
 def get_graph(page):
@@ -274,7 +276,6 @@ def get_graph(page):
         jsn = urllib.parse.unquote(jsn)
 
         grph.parse(data=jsn, format='json-ld')
-
 
     except json.decoder.JSONDecodeError:
         logger.warning("Not a valid JSON document: %s", page)


### PR DESCRIPTION
This PR refactors the parse_page function to enable parsing of documents that are referenced in another doc as a Literal, not a URIRef. A side effect was that circular references could lead to infinite loops. A check was adde to check that already present nodes are not parsed again. For reasons
not completely understood, bnodes may occur multiple times in the parsed graph making the length of a graph a moving test target. Hence, lengths are only checked after filtering out all terms that involve a BNode either as a subject or as an object.

This PR fixes issue #5.

- Serial parsing ok.
- Serial parsing works ok including descending into feature graphs.
- Trying to fix loops.
- WIP: Adding class RecursiveJSONLDParser.
- Fixing test_tripser.
- WIP: Number of terms in recursively parsed graphs is different each time.
- Still WIP.
- Fixing tests
