### PR TITLE
Node serialization and parsing into graph passed to constructor.

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,20 +36,19 @@ class CLITest(unittest.TestCase):
         """Test the CLI with no parameters envoked."""
 
         response = self.runner.invoke(cli)
-
         self.assertEqual(response.exit_code, 2)
 
     def test_cds_11846_serialize_nodes(self):
         """Test parsing a json document with node serialization."""
 
-        self._thrashcan.append('graph.ttl')
 
         response = self.runner.invoke(cli, ['http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/11846', '-s'])
+        self.assertEqual(response.exit_code, 0)
 
         ttls = glob.glob("*.ttl")
         self._thrashcan += ttls
 
-        self.assertEqual(len(ttls), 63)
+        self.assertGreater(len(ttls), 50)
 
     def test_cds_11846_default_output(self):
         """Test parsing a json document and load as graph from default output file."""
@@ -57,9 +56,10 @@ class CLITest(unittest.TestCase):
         # self._thrashcan.append('graph.ttl')
 
         response = self.runner.invoke(cli, ['http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/11846'])
+        self.assertEqual(response.exit_code, 0)
+
         g = Graph().parse('graph.ttl')
 
-        self.assertEqual(response.exit_code, 0)
         self.assertEqual(len([(s, p, o) for (s, p, o) in g if not (isinstance(s, BNode) or isinstance(o, BNode))]), 248)
 
     def test_cds_11846_nondefault_output(self):
@@ -70,9 +70,10 @@ class CLITest(unittest.TestCase):
         response = self.runner.invoke(
             cli, '--out 11846.ttl http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/11846'
         )
+        self.assertEqual(response.exit_code, 0)
+
         g = Graph().parse('11846.ttl')
 
-        self.assertEqual(response.exit_code, 0)
         self.assertEqual(len([(s, p, o) for (s, p, o) in g if not (isinstance(s, BNode) or isinstance(o, BNode))]), 248)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 
 import os
 import shutil
+import glob
 import unittest
 
 from click.testing import CliRunner
@@ -38,10 +39,22 @@ class CLITest(unittest.TestCase):
 
         self.assertEqual(response.exit_code, 2)
 
+    def test_cds_11846_serialize_nodes(self):
+        """Test parsing a json document with node serialization."""
+
+        self._thrashcan.append('graph.ttl')
+
+        response = self.runner.invoke(cli, ['http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/11846', '-s'])
+
+        ttls = glob.glob("*.ttl")
+        self._thrashcan += ttls
+
+        self.assertEqual(len(ttls), 63)
+
     def test_cds_11846_default_output(self):
         """Test parsing a json document and load as graph from default output file."""
 
-        self._thrashcan.append('graph.ttl')
+        # self._thrashcan.append('graph.ttl')
 
         response = self.runner.invoke(cli, ['http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/11846'])
         g = Graph().parse('graph.ttl')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 """:module: test_cli testing module."""
 
+
+import glob
 import os
 import shutil
-import glob
+import sys
 import unittest
 
 from click.testing import CliRunner
@@ -38,9 +40,9 @@ class CLITest(unittest.TestCase):
         response = self.runner.invoke(cli)
         self.assertEqual(response.exit_code, 2)
 
+    @unittest.skipIf(sys.platform.startswith('win'), "Do not run on Windows.")
     def test_cds_11846_serialize_nodes(self):
         """Test parsing a json document with node serialization."""
-
 
         response = self.runner.invoke(cli, ['http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/11846', '-s'])
         self.assertEqual(response.exit_code, 0)

--- a/tests/test_tripser.py
+++ b/tests/test_tripser.py
@@ -94,10 +94,30 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         self.assertIsInstance(parser.graph, Graph)
 
     def test_construction_with_graph(self):
+        """ Test passing an existing graph to the constructor."""
+
+        parser = RecursiveJSONLDParser(graph=Graph())
+
+        self.assertEqual(len([ns for ns in parser.graph.namespace_manager.namespaces()]), 19 )
+    def test_construction_and_parsing_with_graph(self):
         """ Test passing an existing graph to the constructor. Parsed terms
         should be added to the passed graph."""
 
-        raise NotImplementedError
+        g = Graph().parse('http://pflu.evolbio.mpg.de/web-services/content/v0.1/TMRNA')
+        self.assertEqual(len(g), 9)
+
+        parser = RecursiveJSONLDParser(entry_point='http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/11850',
+                                       graph=g)
+
+        # Parse into g.
+        parser.parse()
+        self.assertGreater(len(parser.graph), 9)
+        self.assertEqual(len(g), 9)
+
+        for term in g:
+            self.assertIn(term, parser.graph)
+
+
 
     @unittest.skip("Takes too long.")
     def test_parse_page(self):

--- a/tests/test_tripser.py
+++ b/tests/test_tripser.py
@@ -15,7 +15,6 @@ from tripser.tripser import cleanup, get_graph, remove_terms
 logging.basicConfig(level=logging.INFO)
 
 
-
 class TestRecursiveJSONLDParser(unittest.TestCase):
     def setUp(self):
         """Set up the test case."""
@@ -87,27 +86,29 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         )
 
     def test_construction_default(self):
-        """ Test the default constructor."""
+        """Test the default constructor."""
         parser = RecursiveJSONLDParser()
         self.assertIsNone(parser.entry_point)
         self.assertFalse(parser.serialize_nodes)
         self.assertIsInstance(parser.graph, Graph)
 
     def test_construction_with_graph(self):
-        """ Test passing an existing graph to the constructor."""
+        """Test passing an existing graph to the constructor."""
 
         parser = RecursiveJSONLDParser(graph=Graph())
 
-        self.assertEqual(len([ns for ns in parser.graph.namespace_manager.namespaces()]), 19 )
+        self.assertEqual(len([ns for ns in parser.graph.namespace_manager.namespaces()]), 19)
+
     def test_construction_and_parsing_with_graph(self):
-        """ Test passing an existing graph to the constructor. Parsed terms
+        """Test passing an existing graph to the constructor. Parsed terms
         should be added to the passed graph."""
 
         g = Graph().parse('http://pflu.evolbio.mpg.de/web-services/content/v0.1/TMRNA')
         self.assertEqual(len(g), 9)
 
-        parser = RecursiveJSONLDParser(entry_point='http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/11850',
-                                       graph=g)
+        parser = RecursiveJSONLDParser(
+            entry_point='http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/11850', graph=g
+        )
 
         # Parse into g.
         parser.parse()
@@ -116,8 +117,6 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
 
         for term in g:
             self.assertIn(term, parser.graph)
-
-
 
     @unittest.skip("Takes too long.")
     def test_parse_page(self):
@@ -215,7 +214,7 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         )
 
     def test_namespaces(self):
-        """Test that rdflib namespaces are bound to the graph attribute. """
+        """Test that rdflib namespaces are bound to the graph attribute."""
 
         # Construct the parser.
         parser = RecursiveJSONLDParser(URIRef('http://pflu.evolbio.mpg.de/web-services/content/v0.1/'))
@@ -231,7 +230,7 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
             URIRef('http://pflu.evolbio.mpg.de/web-services/content/v0.1/Gene/'),
             URIRef('http://pflu.evolbio.mpg.de/web-services/content/v0.1/Exon/'),
             URIRef('http://pflu.evolbio.mpg.de/web-services/content/v0.1/Organism/'),
-            URIRef('http://pflu.evolbio.mpg.de/web-services/content/v0.1/Transcript/')
+            URIRef('http://pflu.evolbio.mpg.de/web-services/content/v0.1/Transcript/'),
         ]
 
         for pflu_ns in pflu_namespaces:
@@ -270,16 +269,19 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         self.assertEqual(len(g_1), len(g_2))
 
     def test_get_graph_serialize(self):
-        """Test get_graph() with serialization """
+        """Test get_graph() with serialization"""
 
-        json_url = ('http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/13087/database+cross+reference')
-        self.__thrashcan.append("pflu.evolbio.mpg.de__web-services__content__v0.1__CDS__13087__database+cross+reference.ttl")
+        json_url = 'http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/13087/database+cross+reference'
+        self.__thrashcan.append(
+            "pflu.evolbio.mpg.de__web-services__content__v0.1__CDS__13087__database+cross+reference.ttl"
+        )
         g = get_graph(json_url, True)
 
         self.assertIsInstance(g, Graph)
         self.assertEqual(len(g), 97)
-        self.assertIn('pflu.evolbio.mpg.de__web-services__content__v0.1__CDS__13087__database+cross+reference.ttl', os.listdir())
-
+        self.assertIn(
+            'pflu.evolbio.mpg.de__web-services__content__v0.1__CDS__13087__database+cross+reference.ttl', os.listdir()
+        )
 
     def test_get_graph_corrupt_json(self):
         """Test get_graph() for a corrupt json file."""

--- a/tests/test_tripser.py
+++ b/tests/test_tripser.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import unittest
 
-from rdflib import Graph, URIRef, BNode, Namespace
+from rdflib import Graph, URIRef, BNode
 
 from tripser.tripser import RecursiveJSONLDParser
 from tripser.tripser import cleanup, get_graph, remove_terms

--- a/tests/test_tripser.py
+++ b/tests/test_tripser.py
@@ -15,6 +15,7 @@ from tripser.tripser import cleanup, get_graph, remove_terms
 logging.basicConfig(level=logging.INFO)
 
 
+
 class TestRecursiveJSONLDParser(unittest.TestCase):
     def setUp(self):
         """Set up the test case."""
@@ -84,6 +85,19 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         self.assertEqual(
             len([(s, p, o) for (s, p, o) in cds_graph if not (isinstance(s, BNode) or isinstance(o, BNode))]), 253
         )
+
+    def test_construction_default(self):
+        """ Test the default constructor."""
+        parser = RecursiveJSONLDParser()
+        self.assertIsNone(parser.entry_point)
+        self.assertFalse(parser.serialize_nodes)
+        self.assertIsInstance(parser.graph, Graph)
+
+    def test_construction_with_graph(self):
+        """ Test passing an existing graph to the constructor. Parsed terms
+        should be added to the passed graph."""
+
+        raise NotImplementedError
 
     @unittest.skip("Takes too long.")
     def test_parse_page(self):
@@ -234,6 +248,18 @@ class TestRecursiveJSONLDParser(unittest.TestCase):
         cleanup(g_2)
 
         self.assertEqual(len(g_1), len(g_2))
+
+    def test_get_graph_serialize(self):
+        """Test get_graph() with serialization """
+
+        json_url = ('http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/13087/database+cross+reference')
+        self.__thrashcan.append("pflu.evolbio.mpg.de__web-services__content__v0.1__CDS__13087__database+cross+reference.ttl")
+        g = get_graph(json_url, True)
+
+        self.assertIsInstance(g, Graph)
+        self.assertEqual(len(g), 97)
+        self.assertIn('pflu.evolbio.mpg.de__web-services__content__v0.1__CDS__13087__database+cross+reference.ttl', os.listdir())
+
 
     def test_get_graph_corrupt_json(self):
         """Test get_graph() for a corrupt json file."""

--- a/tripser/cli.py
+++ b/tripser/cli.py
@@ -13,13 +13,17 @@ logger.setLevel(logging.INFO)
 @click.command()
 @click.argument('url')
 @click.option('-o', '--out', default='graph.ttl', help='')
-def cli(url, out):
+@click.option('-s', '--serialize_nodes', is_flag=True, default=False, help='Serialize individual nodes.')
+def cli(url, out, serialize_nodes):
     """Main entrypoint."""
     click.echo("pytripalserializer")
     click.echo("=" * len("pytripalserializer"))
     click.echo("Serialize Tripal's JSON-LD API into RDF.")
 
-    parser = tripser.RecursiveJSONLDParser(url)
+    if serialize_nodes:
+        click.echo("serialize_nodes is set to True")
+
+    parser = tripser.RecursiveJSONLDParser(url, serialize_nodes=serialize_nodes)
 
     try:
         parser.parse()

--- a/tripser/tripser.py
+++ b/tripser/tripser.py
@@ -4,6 +4,7 @@
 import json
 import logging
 import math
+import copy
 
 import urllib
 import requests
@@ -61,23 +62,26 @@ class RecursiveJSONLDParser:
         """ Set the graph attribute"""
         if value is None:
             self.__graph = Graph(bind_namespaces='rdflib')
+        if not isinstance(value, Graph):
+            raise TypeError("Expected instance of rdflib.Graph, received {}".format(type(value)))
         else:
-            self.__graph = value
+            # Copy construct to leave passed graph as is.
+            self.__graph = copy.deepcopy(value)
 
-        self.graph.bind('ssr', Namespace("http://semanticscience.org/resource/"))
-        self.graph.bind('edam', Namespace("http://edamontology.org/"))
-        self.graph.bind('obo', Namespace("http://purl.obolibrary.org/obo/"))
-        self.graph.bind('so', Namespace("http://www.sequenceontology.org/browser/current_svn/term/SO:"))
-        self.graph.bind('hydra', Namespace("http://www.w3.org/ns/hydra/core#"))
-        self.graph.bind('ncbitax', Namespace("https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id="))
-        self.graph.bind("pflutranscript", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/Transcript/"))
-        self.graph.bind("pflu", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/"))
-        self.graph.bind("pflucv", Namespace("http://pflu.evolbio.mpg.de/cv/lookup/local/"))
-        self.graph.bind("pflucds", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/"))
-        self.graph.bind("pflumrna", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/mRNA/"))
-        self.graph.bind("pflugene", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/Gene/"))
-        self.graph.bind("pfluexon", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/Exon/"))
-        self.graph.bind("pfluorganism", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/Organism/"))
+        self.__graph.bind('ssr', Namespace("http://semanticscience.org/resource/"))
+        self.__graph.bind('edam', Namespace("http://edamontology.org/"))
+        self.__graph.bind('obo', Namespace("http://purl.obolibrary.org/obo/"))
+        self.__graph.bind('so', Namespace("http://www.sequenceontology.org/browser/current_svn/term/SO:"))
+        self.__graph.bind('hydra', Namespace("http://www.w3.org/ns/hydra/core#"))
+        self.__graph.bind('ncbitax', Namespace("https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id="))
+        self.__graph.bind("pflutranscript", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/Transcript/"))
+        self.__graph.bind("pflu", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/"))
+        self.__graph.bind("pflucv", Namespace("http://pflu.evolbio.mpg.de/cv/lookup/local/"))
+        self.__graph.bind("pflucds", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/"))
+        self.__graph.bind("pflumrna", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/mRNA/"))
+        self.__graph.bind("pflugene", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/Gene/"))
+        self.__graph.bind("pfluexon", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/Exon/"))
+        self.__graph.bind("pfluorganism", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/Organism/"))
 
 
     @property

--- a/tripser/tripser.py
+++ b/tripser/tripser.py
@@ -25,7 +25,8 @@ class RecursiveJSONLDParser:
         :param graph: Set the initial graph. Parsed terms will be inserted into this graph.
         :type  graph: rdflib.Graph
 
-        :param serialize_nodes: Determines whether parsed documents will be serialized as standalone nodes. Default is False.
+        :param serialize_nodes: Determines whether parsed documents will be serialized
+        as standalone nodes. Default is False.
         :type  serialize_nodes: bool
 
         """
@@ -38,14 +39,14 @@ class RecursiveJSONLDParser:
         self.serialize_nodes = serialize_nodes
         self.entry_point = entry_point
 
-
     @property
     def serialize_nodes(self):
-        """ Get the 'serialize_nodes' flag."""
+        """Get the 'serialize_nodes' flag."""
         return self.__serialize_nodes
+
     @serialize_nodes.setter
     def serialize_nodes(self, value):
-        """ Set the 'serialize_nodes' flag."""
+        """Set the 'serialize_nodes' flag."""
         if value is None:
             value = False
         if not isinstance(value, bool):
@@ -54,14 +55,14 @@ class RecursiveJSONLDParser:
 
     @property
     def graph(self):
-        """ Access the graph of the parser."""
+        """Access the graph of the parser."""
         return self.__graph
 
     @graph.setter
     def graph(self, value):
-        """ Set the graph attribute"""
+        """Set the graph attribute"""
         if value is None:
-            self.__graph = Graph(bind_namespaces='rdflib')
+            value = Graph(bind_namespaces='rdflib')
         if not isinstance(value, Graph):
             raise TypeError("Expected instance of rdflib.Graph, received {}".format(type(value)))
         else:
@@ -74,7 +75,9 @@ class RecursiveJSONLDParser:
         self.__graph.bind('so', Namespace("http://www.sequenceontology.org/browser/current_svn/term/SO:"))
         self.__graph.bind('hydra', Namespace("http://www.w3.org/ns/hydra/core#"))
         self.__graph.bind('ncbitax', Namespace("https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id="))
-        self.__graph.bind("pflutranscript", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/Transcript/"))
+        self.__graph.bind(
+            "pflutranscript", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/Transcript/")
+        )
         self.__graph.bind("pflu", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/"))
         self.__graph.bind("pflucv", Namespace("http://pflu.evolbio.mpg.de/cv/lookup/local/"))
         self.__graph.bind("pflucds", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/CDS/"))
@@ -82,7 +85,6 @@ class RecursiveJSONLDParser:
         self.__graph.bind("pflugene", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/Gene/"))
         self.__graph.bind("pfluexon", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/Exon/"))
         self.__graph.bind("pfluorganism", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/Organism/"))
-
 
     @property
     def parsed_pages(self):
@@ -333,14 +335,14 @@ def get_graph(page, serialize=False):
     except requests.exceptions.JSONDecodeError:
         logger.warning("Not a valid JSON document: %s", page)
 
-    except:
+    except Exception as e:
         logger.error("Exception thrown while parsing %s.", page)
-        raise
+        raise e
 
     logger.debug("Parsed %d terms.", len(grph))
 
     if serialize:
-        ofname = page.split("://")[-1].replace("/", "__")+".ttl"
+        ofname = page.split("://")[-1].replace("/", "__") + ".ttl"
         logger.info("Writing %s to %s.", page, ofname)
         grph.serialize(ofname)
 

--- a/tripser/tripser.py
+++ b/tripser/tripser.py
@@ -15,17 +15,55 @@ logger = logging.getLogger(__name__)
 class RecursiveJSONLDParser:
     """:class: This class implements recursive parsing of JSON-LD documents."""
 
-    def __init__(self, entry_point=None):
+    def __init__(self, entry_point=None, graph=None, serialize_nodes=False):
         """Initialize the recursine JSON-LD parser.
 
         :param root: The entry point for parsing.
         :type  root: str | rdflib.URIRef | rdflib.Literal
 
+        :param graph: Set the initial graph. Parsed terms will be inserted into this graph.
+        :type  graph: rdflib.Graph
+
+        :param serialize_nodes: Determines whether parsed documents will be serialized as standalone nodes. Default is False.
+        :type  serialize_nodes: bool
+
         """
 
+        # Init hidden attributes.
         self.__parsed_pages = []
 
-        self.graph = Graph(bind_namespaces='rdflib')
+        # Init public attributes.
+        self.graph = graph
+        self.serialize_nodes = serialize_nodes
+        self.entry_point = entry_point
+
+
+    @property
+    def serialize_nodes(self):
+        """ Get the 'serialize_nodes' flag."""
+        return self.__serialize_nodes
+    @serialize_nodes.setter
+    def serialize_nodes(self, value):
+        """ Set the 'serialize_nodes' flag."""
+        if value is None:
+            value = False
+        if not isinstance(value, bool):
+            raise TypeError("Parameter 'serialize_nodes' must be a bool, got {}.".format(type(value)))
+        self.__serialize_nodes = value
+
+    @property
+    def graph(self):
+        """ Access the graph of the parser."""
+        return self.__graph
+
+    @graph.setter
+    def graph(self, value):
+        """ Set the graph attribute"""
+        if value is None:
+            self.__graph = Graph(bind_namespaces='rdflib')
+        else:
+            self.__graph = value
+
         self.graph.bind('ssr', Namespace("http://semanticscience.org/resource/"))
         self.graph.bind('edam', Namespace("http://edamontology.org/"))
         self.graph.bind('obo', Namespace("http://purl.obolibrary.org/obo/"))
@@ -41,7 +79,6 @@ class RecursiveJSONLDParser:
         self.graph.bind("pfluexon", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/Exon/"))
         self.graph.bind("pfluorganism", Namespace("http://pflu.evolbio.mpg.de/web-services/content/v0.1/Organism/"))
 
-        self.entry_point = URIRef(entry_point)
 
     @property
     def parsed_pages(self):
@@ -52,22 +89,17 @@ class RecursiveJSONLDParser:
         raise RuntimeError("parsed_pages is a read-only property.")
 
     @property
-    def graph(self):
-        return self.__graph
-
-    @graph.setter
-    def graph(self, value):
-        if isinstance(value, Graph):
-            self.__graph = value
-        else:
-            raise TypeError("{} is not a rdflib.Graph instance.".format(value))
-
-    @property
     def entry_point(self):
         return self.__entry_point
 
     @entry_point.setter
     def entry_point(self, value):
+
+        if value is None:
+            logging.warning("No entry point set. Set the entry point before parsing.")
+            self.__entry_point = None
+            return
+
         if isinstance(value, str):
             value = URIRef(value)
 
@@ -77,6 +109,11 @@ class RecursiveJSONLDParser:
             self.__entry_point = value
 
     def parse(self):
+        if self.entry_point is None:
+            self.entry_point = None
+            return
+
+        # else: parse
         self.graph += self.parse_page(self.entry_point)
 
     def parse_page(self, page):
@@ -95,7 +132,7 @@ class RecursiveJSONLDParser:
 
         logger.debug("parse_page(page=%s)", str(page))
 
-        grph = get_graph(page)
+        grph = get_graph(page, self.serialize_nodes)
 
         logger.debug("# Terms")
         for term in grph:
@@ -262,7 +299,7 @@ def remove_terms(grph, terms):
     logger.debug("Removed %d terms matching triple pattern (%s, %s, %s).", count, *terms)
 
 
-def get_graph(page):
+def get_graph(page, serialize=False):
     """Workhorse function to download the json document and parse into the graph to be returned.
 
     :param page: The URL of the json-ld document to download and parse.
@@ -292,9 +329,15 @@ def get_graph(page):
     except requests.exceptions.JSONDecodeError:
         logger.warning("Not a valid JSON document: %s", page)
 
-    except BaseException:
+    except:
         logger.error("Exception thrown while parsing %s.", page)
         raise
 
     logger.debug("Parsed %d terms.", len(grph))
+
+    if serialize:
+        ofname = page.split("://")[-1].replace("/", "__")+".ttl"
+        logger.info("Writing %s to %s.", page, ofname)
+        grph.serialize(ofname)
+
     return grph


### PR DESCRIPTION
## Summary
This PR addresses issue #7. One can now pass an existing graph to 
`RecursiveJSONLDParser.__init__()` and calling `.parse()` would then parse into the
passed graph.

Additionally, I implemented the option to serialize the results of `get_graph` into a ttl file. The filename is the URL with '/' replaced by '__' and with 'http[s]://' stripped.

With these changes, after a crash,  one can now reconstruct the graph from the serialized nodes and restart parsing.

## List of changes
- Implemented and tested node serialization.
- Implemented and tested parsing into existing graph.
